### PR TITLE
feat: add relu range restriction

### DIFF
--- a/Script/vessl_code/base_fault_injection.py
+++ b/Script/vessl_code/base_fault_injection.py
@@ -5,21 +5,6 @@ from pytorchfi.core import FaultInjection
 from bitstring import BitArray
 from collections import deque
 
-class add_input_layer(torch.nn.Module):
-    '''
-    You can use this class when you want fault injection to input tensor itself.    
-    '''
-    def __init__(self, model, *args):
-        super().__init__(*args)
-        self.input_layer = torch.nn.Identity()
-        self.model = model
-
-    def forward(self, x):
-        input = self.input_layer(x)
-        output = self.model(input)
-        return output
-
-
 class single_bit_flip_model(FaultInjection):
     def __init__(self, model, batch_size, flip_bit_pos=None, save_log_list=False, flip_bit_pos_list=[], **kwargs):
         super().__init__(model, batch_size, **kwargs)

--- a/Script/vessl_code/neuron.py
+++ b/Script/vessl_code/neuron.py
@@ -11,7 +11,8 @@ import vessl
 
 from torchvision import transforms
 
-from base_fault_injection import add_input_layer, single_bit_flip_model
+from base_fault_injection import single_bit_flip_model
+from utils import add_input_layer
 
 import pytorchfi # git clone https://github.com/WaiNaat/pytorchfi.git
 from pytorchfi.core import FaultInjection

--- a/Script/vessl_code/relu6_neuron.py
+++ b/Script/vessl_code/relu6_neuron.py
@@ -42,7 +42,8 @@ import vessl
 from torchvision import transforms
 from collections import deque
 
-from base_fault_injection import add_input_layer, single_bit_flip_model
+from base_fault_injection import single_bit_flip_model
+from utils import add_input_layer
 
 import pytorchfi # git clone https://github.com/WaiNaat/pytorchfi.git
 from pytorchfi.core import FaultInjection

--- a/Script/vessl_code/relu_restriction_neuron.py
+++ b/Script/vessl_code/relu_restriction_neuron.py
@@ -212,12 +212,10 @@ for layer_num in layer_nums:
             corrupted_output = corrupted_model(images)
 
         # robust model inference
-        print('=====')
-        print('robust model')
         robust_model.eval()
         with torch.no_grad():
             robust_output = robust_model(images)
-        print(robust_output)
+            
         # make corrupted robust model
         base_fi_robust_model.reset_log()
         base_fi_robust_model.flip_bit_pos_deque = deque(base_fi_model.log_bit_pos)
@@ -233,11 +231,10 @@ for layer_num in layer_nums:
         restriction_tool.restrict_relu(corrupted_robust_model)
 
         # corrupted robust model inference
-        print('corrupted robust model')
         corrupted_robust_model.eval()
         with torch.no_grad():
             corrupted_robust_output = corrupted_robust_model(images)
-        print(corrupted_robust_output)
+            
         # get label
         original_output = torch.argmax(orig_output, dim=1).cpu().numpy()
         corrupted_output = torch.argmax(corrupted_output, dim=1).cpu().numpy()

--- a/Script/vessl_code/relu_restriction_neuron.py
+++ b/Script/vessl_code/relu_restriction_neuron.py
@@ -167,7 +167,9 @@ for layer_num in layer_nums:
     for images, labels in dataloader:
 
         batch_idx += 1
-        if batch_idx > 3: exit()
+        if batch_idx > 3:
+            print('\n'.join(error_logs))
+            exit()
 
         images = images.to(device)
 

--- a/Script/vessl_code/relu_restriction_neuron.py
+++ b/Script/vessl_code/relu_restriction_neuron.py
@@ -105,9 +105,6 @@ elif dataset == 'cifar100':
 else:
     raise AssertionError(f'Invalid dataset name {dataset}')
 
-# make tool for activation restriction
-restriction_tool = module_restriction(restriction_max_value=relu_restriction_max_value, restriction_min_value=relu_restriction_min_value)
-
 # make fault injection base model
 base_fi_model = single_bit_flip_model(
     model = copy.deepcopy(model),
@@ -119,6 +116,13 @@ base_fi_model = single_bit_flip_model(
 )
 
 print(base_fi_model.print_pytorchfi_layer_summary(), end='\n\n')
+
+# make tool for activation restriction
+restriction_tool = module_restriction(
+    restriction_max_value = relu_restriction_max_value, 
+    restriction_min_value = relu_restriction_min_value,
+    device = device
+)
 
 # make robust model
 robust_model_base = copy.deepcopy(model)

--- a/Script/vessl_code/relu_restriction_neuron.py
+++ b/Script/vessl_code/relu_restriction_neuron.py
@@ -136,7 +136,7 @@ base_fi_robust_model = single_bit_flip_model(
     save_log_list = args.detailed_log
 )
 
-print(base_fi_robust_model.print_pytorchfi_layer_summary(), end='\n\n')
+#print(base_fi_robust_model.print_pytorchfi_layer_summary(), end='\n\n')
 
 # fault injection layer range setting
 if layer_nums != 'all':

--- a/Script/vessl_code/relu_restriction_neuron.py
+++ b/Script/vessl_code/relu_restriction_neuron.py
@@ -212,6 +212,8 @@ for layer_num in layer_nums:
             corrupted_output = corrupted_model(images)
 
         # robust model inference
+        print('=====')
+        print('robust model')
         robust_model.eval()
         with torch.no_grad():
             robust_output = robust_model(images)
@@ -231,6 +233,7 @@ for layer_num in layer_nums:
         restriction_tool.restrict_relu(corrupted_robust_model)
 
         # corrupted robust model inference
+        print('corrupted robust model')
         corrupted_robust_model.eval()
         with torch.no_grad():
             corrupted_robust_output = corrupted_robust_model(images)

--- a/Script/vessl_code/relu_restriction_neuron.py
+++ b/Script/vessl_code/relu_restriction_neuron.py
@@ -1,5 +1,7 @@
 '''
-vgg19의 relu를 relu6로 교체
+activation restriction 대상 모델은
+declare_neuron_fault_injection 이후에
+activation만 골라서 forward hook을 추가로 걸어준다 
 '''
 
 import torch
@@ -16,11 +18,11 @@ import vessl
 from torchvision import transforms
 from collections import deque
 
-from base_fault_injection import single_bit_flip_model
-from utils import add_input_layer
+from base_fault_injection import add_input_layer, single_bit_flip_model
 
 import pytorchfi # git clone https://github.com/WaiNaat/pytorchfi.git
-from pytorchfi.weight_error_models import random_weight_location
+from pytorchfi.core import FaultInjection
+from pytorchfi.neuron_error_models import random_neuron_location
 
 vessl.init()
 
@@ -69,6 +71,7 @@ random.seed(seed)
 
 # load model
 model = torch.hub.load("chenyaofo/pytorch-cifar-models", dataset + '_' + model_name, pretrained=True)
+model = add_input_layer(model)
 model.to(device)
 
 print(model, end='\n\n')
@@ -147,122 +150,99 @@ else:
 
 # experiment
 print(f'Seed: {seed}')
-
-# 실험 진행
 results = []
-layer_name = []
 misclassification_rate = []
-detailed_log = []
+layer_name = []
+error_logs = []
 
-# layer 순회
 for layer_num in layer_nums:
-
-    # 우선 해당 레이어에 weight값이 있는지부터 확인
-    try:
-        layer, k, C, H, W = random_weight_location(base_fi_model, layer=layer_num)
-    except:
-        result = f"Layer #{layer_num} has no weight"
-        print(result)
-        results.append(result)
-        continue
-
+    
     orig_correct_cnt = 0
-    corrupt_correct_cnt = 0
     robust_correct_cnt = 0
+    corrupt_correct_cnt = 0
+    corruped_robust_correct_cnt = 0
     orig_corrupt_diff_cnt = 0
     orig_robust_diff_cnt = 0
     batch_idx = -1
-
-    # batch 순회
+    
     for images, labels in dataloader:
 
         batch_idx += 1
+
         images = images.to(device)
 
-        # 원본에 inference 진행
+        # original model inference
         model.eval()
         with torch.no_grad():
             orig_output = model(images)
 
-        # fault injection 위치 선정
-        layer, k, C, H, W = random_weight_location(base_fi_model, layer=layer_num)
+        # determine single bit flip position
+        layer_num_list = []
+        dim1 = []
+        dim2 = []
+        dim3 = []
 
-        # corrupted model 만들기
-        if args.detailed_log:
-            base_fi_model.reset_log()
+        for _ in range(batch_size):
+            layer, C, H, W = random_neuron_location(base_fi_model, layer=layer_num)
 
-        corrupted_model = base_fi_model.declare_weight_fault_injection(
-            function = base_fi_model.weight_single_bit_flip_function,
-            layer_num = layer,
-            k = k,
-            dim1 = C,
-            dim2 = H,
-            dim3 = W
+            layer_num_list.append(layer)
+            dim1.append(C)
+            dim2.append(H)
+            dim3.append(W)
+
+        # make corrupted model
+        base_fi_model.reset_log()
+        corrupted_model = base_fi_model.declare_neuron_fault_injection(
+            batch = [i for i in range(batch_size)],
+            layer_num = layer_num_list,
+            dim1 = dim1,
+            dim2 = dim2,
+            dim3 = dim3,
+            function = base_fi_model.neuron_single_bit_flip_function
         )
 
-        if args.detailed_log:
-            log = [
-                f'Model',
-                f'Layer: {layer_num}',
-                f'''Layer type: {str(base_fi_model.layers_type[layer_num]).split(".")[-1].split("'")[0]}''',
-                f'Position: ({k[0]}, {C[0]}, {H[0]}, {W[0]})',
-                f'Original value:  {base_fi_model.log_original_value[0]}',
-                f'Original binary: {base_fi_model.log_original_value_bin[0]}',
-                f'Flip bit: {base_fi_model.log_bit_pos[0]}',
-                f'Error value:     {base_fi_model.log_error_value[0]}',
-                f'Error binary:    {base_fi_model.log_error_value_bin[0]}',
-            ]
-
-            detailed_log.append('\n'.join(log))
-
-        # corrupted model에 inference 진행
+        # corrupted model inference
         corrupted_model.eval()
         with torch.no_grad():
             corrupted_output = corrupted_model(images)
-
-        # make robust model
-        base_fi_robust_model.reset_log()
-        base_fi_robust_model.flip_bit_pos_deque = deque(base_fi_model.log_bit_pos)
-        robust_model = base_fi_robust_model.declare_weight_fault_injection(
-            function = base_fi_robust_model.weight_single_bit_flip_function,
-            layer_num = layer,
-            k = k,
-            dim1 = C,
-            dim2 = H,
-            dim3 = W
-        )
-
-        if args.detailed_log:
-            log = [
-                f'Robust model',
-                f'Layer: {layer_num}',
-                f'''Layer type: {str(base_fi_robust_model.layers_type[layer_num]).split(".")[-1].split("'")[0]}''',
-                f'Position: ({k[0]}, {C[0]}, {H[0]}, {W[0]})',
-                f'Original value:  {base_fi_robust_model.log_original_value[0]}',
-                f'Original binary: {base_fi_robust_model.log_original_value_bin[0]}',
-                f'Flip bit: {base_fi_robust_model.log_bit_pos[0]}',
-                f'Error value:     {base_fi_robust_model.log_error_value[0]}',
-                f'Error binary:    {base_fi_robust_model.log_error_value_bin[0]}',
-            ]
-
-            detailed_log.append('\n'.join(log))
 
         # robust model inference
         robust_model.eval()
         with torch.no_grad():
             robust_output = robust_model(images)
 
-        # 결과 정리
+        # make corrupted robust model
+        base_fi_robust_model.reset_log()
+        base_fi_robust_model.flip_bit_pos_deque = deque(base_fi_model.log_bit_pos)
+        corrupted_robust_model = base_fi_robust_model.declare_neuron_fault_injection(
+            batch = [i for i in range(batch_size)],
+            layer_num = layer_num_list,
+            dim1 = dim1,
+            dim2 = dim2,
+            dim3 = dim3,
+            function = base_fi_robust_model.neuron_single_bit_flip_function
+        )
+
+        # corrupted robust model inference
+        corrupted_robust_model.eval()
+        with torch.no_grad():
+            corrupted_robust_output = corrupted_robust_model(images)
+
+        # get label
         original_output = torch.argmax(orig_output, dim=1).cpu().numpy()
         corrupted_output = torch.argmax(corrupted_output, dim=1).cpu().numpy()
         robust_output = torch.argmax(robust_output, dim=1).cpu().numpy()
+        corrupted_robust_output = torch.argmax(corrupted_robust_output, dim=1).cpu().numpy()
         labels = labels.numpy()
-        
-        # 결과 비교: 원본이 정답을 맞춘 경우 중 망가진 모델이 틀린 경우를 셈
+
+        # calc result
         for i in range(batch_size):
-    
+
             if labels[i] == corrupted_output[i]:
                 corrupt_correct_cnt += 1
+
+            if labels[i] == corrupted_robust_output[i]:
+                corruped_robust_correct_cnt += 1
 
             if labels[i] == robust_output[i]:
                 robust_correct_cnt += 1
@@ -273,42 +253,65 @@ for layer_num in layer_nums:
                 if original_output[i] != corrupted_output[i]:
                     orig_corrupt_diff_cnt += 1
 
-                if original_output[i] != robust_output[i]:
+                if original_output[i] != corrupted_robust_output[i]:
                     orig_robust_diff_cnt += 1
 
-                if args.detailed_log and robust_output[i] != corrupted_output[i]:
-                    detailed_log.append(f'Batch: {batch_idx}\nImage: {i}\nLabel: {labels[i]}\nCorrupted output: {corrupted_output[i]}\nRobust output: {robust_output[i]}')
+                if args.detailed_log and corrupted_robust_output[i] != corrupted_output[i]:
+                        log = [
+                            f'Layer: {layer_num}',
+                            f'Batch: {batch_idx}',
+                            f'Position: ({i}, {dim1[i]}, {dim2[i]}, {dim3[i]})',
+                            f'Original value:  {base_fi_model.log_original_value[i]}',
+                            f'Original binary: {base_fi_model.log_original_value_bin[i]}',
+                            f'Flip bit: {base_fi_model.log_bit_pos[i]}',
+                            f'Error value:     {base_fi_model.log_error_value[i]}',
+                            f'Error binary:    {base_fi_model.log_error_value_bin[i]}',
+                            f'Original value(robust model):  {base_fi_robust_model.log_original_value[i]}',
+                            f'Original binary(robust model): {base_fi_robust_model.log_original_value_bin[i]}',
+                            f'Error value(robust model):     {base_fi_robust_model.log_error_value[i]}',
+                            f'Error binary(robust model):    {base_fi_robust_model.log_error_value_bin[i]}',
+                            f'Label:        {labels[i]}',
+                            f'Corrupted model output: {corrupted_output[i]}',
+                            f'Robust model output: {corrupted_robust_output[i]}'
+                            '\n'
+                        ]
 
+                        error_logs.append('\n'.join(log))
 
-    # 결과 저장
+    # save result
     total_imgs = (batch_idx + 1) * batch_size
     acc_orig = orig_correct_cnt / total_imgs * 100
     acc_corrupt = corrupt_correct_cnt / total_imgs * 100
     acc_robust = robust_correct_cnt / total_imgs * 100
+    acc_corrupted_robust = corruped_robust_correct_cnt / total_imgs * 100
     rate = orig_corrupt_diff_cnt / orig_correct_cnt * 100
     rate2 = orig_robust_diff_cnt / orig_correct_cnt * 100
 
     result = f'Layer #{layer_num}:'
     result += f'\n    {orig_corrupt_diff_cnt} / {orig_correct_cnt} = {rate:.4f}%, ' + str(base_fi_model.layers_type[layer_num]).split(".")[-1].split("'")[0]
     result += f'\n    {orig_robust_diff_cnt} / {orig_correct_cnt} = {rate2:.4f}%, ' + str(base_fi_robust_model.layers_type[layer_num]).split(".")[-1].split("'")[0]
-    result += f'\n    Accuracy: Original {acc_orig:.2f}%, Corrupt {acc_corrupt:.2f}%, Robust {acc_robust:.2f}%'
+    result += f'\n    Accuracy: Original {acc_orig:.2f}%, Corrupt {acc_corrupt:.2f}%, Robust {acc_robust:.2f}%, Corrupted-robust {acc_corrupted_robust:.2f}%'
     print(result)
 
     results.append(result)
     misclassification_rate.append(rate)
     layer_name.append(str(base_fi_model.layers_type[layer_num]).split(".")[-1].split("'")[0])
-    vessl.log(step=layer_num, payload={'Misclassification_rate_corrupted_model': rate})
+    vessl.log(step=layer_num, payload={'Misclassification_rate_original_model': rate})
     vessl.log(step=layer_num, payload={'Misclassification_rate_robust_model': rate2})
     vessl.log(step=layer_num, payload={'diff': rate2 - rate})
+    vessl.log(step=layer_num, payload={'acc_corrupted': acc_corrupt})
+    vessl.log(step=layer_num, payload={'acc_robust': acc_robust})
+    vessl.log(step=layer_num, payload={'acc_corrupted_robust': acc_corrupted_robust})
 
 # save log file
 # save overall log
-save_path = os.path.join(args.output_path, '_'.join(['weight', model_name, dataset, str(seed)]))
+save_path = os.path.join(args.output_path, '_'.join(['neuron', model_name, dataset, str(seed)]))
 vessl.log({'seed': seed})
 
 f = open(save_path + '.txt', 'w')
 
 f.write(base_fi_model.print_pytorchfi_layer_summary())
+f.write(base_fi_robust_model.print_pytorchfi_layer_summary())
 f.write(f'\n\n===== Result =====\nSeed: {seed}\nSpecific bit flip position: {bit_flip_pos}\n')
 for result in results:
     f.write(result + '\n')
@@ -319,8 +322,8 @@ f.close()
 if args.detailed_log:
     f = open(save_path + '_detailed.txt', 'w')
 
-    for error_log in detailed_log:
-        f.write(error_log + '\n\n')
+    for error_log in error_logs:
+        f.write(error_log + '\n')
 
     f.close()
 

--- a/Script/vessl_code/relu_restriction_neuron.py
+++ b/Script/vessl_code/relu_restriction_neuron.py
@@ -171,9 +171,6 @@ for layer_num in layer_nums:
     for images, labels in dataloader:
 
         batch_idx += 1
-        if batch_idx > 3:
-            exit()
-
         images = images.to(device)
 
         # original model inference

--- a/Script/vessl_code/relu_restriction_neuron.py
+++ b/Script/vessl_code/relu_restriction_neuron.py
@@ -168,7 +168,6 @@ for layer_num in layer_nums:
 
         batch_idx += 1
         if batch_idx > 3:
-            print('\n'.join(error_logs))
             exit()
 
         images = images.to(device)

--- a/Script/vessl_code/relu_restriction_neuron.py
+++ b/Script/vessl_code/relu_restriction_neuron.py
@@ -217,7 +217,7 @@ for layer_num in layer_nums:
         robust_model.eval()
         with torch.no_grad():
             robust_output = robust_model(images)
-
+        print(robust_output)
         # make corrupted robust model
         base_fi_robust_model.reset_log()
         base_fi_robust_model.flip_bit_pos_deque = deque(base_fi_model.log_bit_pos)
@@ -237,7 +237,7 @@ for layer_num in layer_nums:
         corrupted_robust_model.eval()
         with torch.no_grad():
             corrupted_robust_output = corrupted_robust_model(images)
-
+        print(corrupted_robust_output)
         # get label
         original_output = torch.argmax(orig_output, dim=1).cpu().numpy()
         corrupted_output = torch.argmax(corrupted_output, dim=1).cpu().numpy()

--- a/Script/vessl_code/utils.py
+++ b/Script/vessl_code/utils.py
@@ -24,12 +24,11 @@ class module_restriction:
 
     def restrict_relu(self, model):
         fhooks = []
-        for name, module in model.named_children():
+        for name, module in model.named_modules():
             if type(module) == torch.nn.ReLU or type(module) == torch.nn.ReLU6:
                 fhooks.append(
                     module.register_forward_hook(self._restriction_hook)
                 )
-                print(f'register forward hook to {type(module)}')
         return fhooks
 
     def _restriction_hook(self, module, input, output):

--- a/Script/vessl_code/utils.py
+++ b/Script/vessl_code/utils.py
@@ -20,6 +20,7 @@ class module_restriction:
             raise ValueError('restriction_max_value must be greater than or equal to restriction_min_value.')
         self.restriction_max_value = torch.Tensor([restriction_max_value])
         self.restriction_min_value = torch.Tensor([restriction_min_value])
+        print(f'restriction info: max {restriction_max_value}, min {restriction_min_value}\n')
 
     def restrict_relu(self, model):
         fhooks = []

--- a/Script/vessl_code/utils.py
+++ b/Script/vessl_code/utils.py
@@ -28,6 +28,7 @@ class module_restriction:
                 fhooks.append(
                     module.register_forward_hook(self._restriction_hook)
                 )
+                print(f'register forward hook to {type(module)}')
         return fhooks
 
     def _restriction_hook(self, module, input, output):

--- a/Script/vessl_code/utils.py
+++ b/Script/vessl_code/utils.py
@@ -1,0 +1,16 @@
+import torch
+import copy
+
+class add_input_layer(torch.nn.Module):
+    '''
+    You can use this class when you want fault injection to input tensor itself.    
+    '''
+    def __init__(self, model, *args):
+        super().__init__(*args)
+        self.input_layer = torch.nn.Identity()
+        self.model = model
+
+    def forward(self, x):
+        input = self.input_layer(x)
+        output = self.model(input)
+        return output

--- a/Script/vessl_code/utils.py
+++ b/Script/vessl_code/utils.py
@@ -15,12 +15,12 @@ class add_input_layer(torch.nn.Module):
         return output
 
 class module_restriction:
-    def __init__(self, restriction_max_value=2147483647, restriction_min_value=-2147483647, device='cuda'):
+    def __init__(self, restriction_max_value=float('inf'), restriction_min_value=-float('inf'), device='cuda'):
         if restriction_max_value < restriction_min_value:
             raise ValueError('restriction_max_value must be greater than or equal to restriction_min_value.')
         self.restriction_max_value = torch.Tensor([restriction_max_value]).to(device)
         self.restriction_min_value = torch.Tensor([restriction_min_value]).to(device)
-        print(f'restriction info: max {restriction_max_value}, min {restriction_min_value}\n')
+        print(f'Restriction info: max {restriction_max_value}, min {restriction_min_value}\n')
 
     def restrict_relu(self, model):
         fhooks = []
@@ -29,11 +29,8 @@ class module_restriction:
                 fhooks.append(
                     module.register_forward_hook(self._restriction_hook)
                 )
-                print('registered forward hook to relu')
         return fhooks
 
     def _restriction_hook(self, module, input, output):
-        print(f'BEFORE:: max:{torch.max(output)} min:{torch.min(output)}')
         torch.fmin(output, self.restriction_max_value, out=output)
         torch.fmax(output, self.restriction_min_value, out=output)
-        print(f'AFTER::  max:{torch.max(output)} min:{torch.min(output)}')

--- a/Script/vessl_code/utils.py
+++ b/Script/vessl_code/utils.py
@@ -1,5 +1,4 @@
 import torch
-import copy
 
 class add_input_layer(torch.nn.Module):
     '''
@@ -15,28 +14,23 @@ class add_input_layer(torch.nn.Module):
         output = self.model(input)
         return output
 
-class activation_restriction_model(torch.nn.Module):
-    def __init__(self, model, restriction_max_value=2147483647, restriction_min_value=-2147483647, *args):
+class module_restriction:
+    def __init__(self, restriction_max_value=2147483647, restriction_min_value=-2147483647):
         if restriction_max_value < restriction_min_value:
             raise ValueError('restriction_max_value must be greater than or equal to restriction_min_value.')
-        super().__init__(*args)
-        self.model = copy.deepcopy(model)
         self.restriction_max_value = torch.Tensor([restriction_max_value])
         self.restriction_min_value = torch.Tensor([restriction_min_value])
 
-    def forward(self, input):
-        return self.model(input)
-
-    def restrict_relu(self):
+    def restrict_relu(self, model):
         fhooks = []
-        for name, module in self.model.named_children():
+        for name, module in model.named_children():
             if type(module) == torch.nn.ReLU or type(module) == torch.nn.ReLU6:
                 fhooks.append(
-                    module.register_forward_hook(self.relu_restriction_hook)
+                    module.register_forward_hook(self._restriction_hook)
                 )
         return fhooks
 
-    def relu_restriction_hook(self, module, input, output):
+    def _restriction_hook(self, module, input, output):
         torch.minimum(output, self.restriction_max_value, out=output)
         torch.maximum(output, self.restriction_min_value, out=output)
         print(f'max:{torch.max(output)} min:{torch.min(output)}')

--- a/Script/vessl_code/utils.py
+++ b/Script/vessl_code/utils.py
@@ -34,6 +34,6 @@ class module_restriction:
 
     def _restriction_hook(self, module, input, output):
         print(f'BEFORE:: max:{torch.max(output)} min:{torch.min(output)}')
-        torch.minimum(output, self.restriction_max_value, out=output)
-        torch.maximum(output, self.restriction_min_value, out=output)
+        torch.fmin(output, self.restriction_max_value, out=output)
+        torch.fmax(output, self.restriction_min_value, out=output)
         print(f'AFTER::  max:{torch.max(output)} min:{torch.min(output)}')

--- a/Script/vessl_code/utils.py
+++ b/Script/vessl_code/utils.py
@@ -15,11 +15,11 @@ class add_input_layer(torch.nn.Module):
         return output
 
 class module_restriction:
-    def __init__(self, restriction_max_value=2147483647, restriction_min_value=-2147483647):
+    def __init__(self, restriction_max_value=2147483647, restriction_min_value=-2147483647, device='cuda'):
         if restriction_max_value < restriction_min_value:
             raise ValueError('restriction_max_value must be greater than or equal to restriction_min_value.')
-        self.restriction_max_value = torch.Tensor([restriction_max_value])
-        self.restriction_min_value = torch.Tensor([restriction_min_value])
+        self.restriction_max_value = torch.Tensor([restriction_max_value]).to(device)
+        self.restriction_min_value = torch.Tensor([restriction_min_value]).to(device)
         print(f'restriction info: max {restriction_max_value}, min {restriction_min_value}\n')
 
     def restrict_relu(self, model):

--- a/Script/vessl_code/utils.py
+++ b/Script/vessl_code/utils.py
@@ -29,6 +29,7 @@ class module_restriction:
                 fhooks.append(
                     module.register_forward_hook(self._restriction_hook)
                 )
+                print('registered forward hook to relu')
         return fhooks
 
     def _restriction_hook(self, module, input, output):

--- a/Script/vessl_code/utils.py
+++ b/Script/vessl_code/utils.py
@@ -32,6 +32,7 @@ class module_restriction:
         return fhooks
 
     def _restriction_hook(self, module, input, output):
+        print(f'BEFORE:: max:{torch.max(output)} min:{torch.min(output)}')
         torch.minimum(output, self.restriction_max_value, out=output)
         torch.maximum(output, self.restriction_min_value, out=output)
-        print(f'max:{torch.max(output)} min:{torch.min(output)}')
+        print(f'AFTER::  max:{torch.max(output)} min:{torch.min(output)}')

--- a/Script/vessl_code/utils.py
+++ b/Script/vessl_code/utils.py
@@ -14,3 +14,29 @@ class add_input_layer(torch.nn.Module):
         input = self.input_layer(x)
         output = self.model(input)
         return output
+
+class activation_restriction_model(torch.nn.Module):
+    def __init__(self, model, restriction_max_value=2147483647, restriction_min_value=-2147483647, *args):
+        if restriction_max_value < restriction_min_value:
+            raise ValueError('restriction_max_value must be greater than or equal to restriction_min_value.')
+        super().__init__(*args)
+        self.model = copy.deepcopy(model)
+        self.restriction_max_value = torch.Tensor([restriction_max_value])
+        self.restriction_min_value = torch.Tensor([restriction_min_value])
+
+    def forward(self, input):
+        return self.model(input)
+
+    def restrict_relu(self):
+        fhooks = []
+        for name, module in self.model.named_children():
+            if type(module) == torch.nn.ReLU or type(module) == torch.nn.ReLU6:
+                fhooks.append(
+                    module.register_forward_hook(self.relu_restriction_hook)
+                )
+        return fhooks
+
+    def relu_restriction_hook(self, module, input, output):
+        torch.minimum(output, self.restriction_max_value, out=output)
+        torch.maximum(output, self.restriction_min_value, out=output)
+        print(f'max:{torch.max(output)} min:{torch.min(output)}')

--- a/Script/vessl_code/weight.py
+++ b/Script/vessl_code/weight.py
@@ -12,6 +12,7 @@ import vessl
 from torchvision import transforms
 
 from base_fault_injection import single_bit_flip_model
+from utils import add_input_layer
 
 import pytorchfi # git clone https://github.com/WaiNaat/pytorchfi.git
 from pytorchfi.weight_error_models import random_weight_location


### PR DESCRIPTION
1. `utils.py`
forward hook을 이용해 relu의 출력값이 일정 범위 안에 위치하도록 통제.
만약 다른 종류의 레이어에도 적용하고 싶다면 `restrict_relu`와 `_restriction_hook`을 참고해서 새로 짜면 됨
```
tool = new module_restriction(restriction_max_value, restriction_min_value)
forward_hooks = tool.restrict_relu(model)
```

2. `relu_restriction_neuron.py`
다른 건 다 똑같은데 vessl.ai hyperparameter로 `relu_restriction_max_value`와 `relu_restriction_min_value`를 입력해 조절 가능.
이 두 값은 코드 내에서 int형으로 바꾸게 되어있으므로 float를 사용하고 싶을 시 코드 수정 필요.